### PR TITLE
remove the video bitrate formatting

### DIFF
--- a/BDInfo/FormReport.cs
+++ b/BDInfo/FormReport.cs
@@ -521,7 +521,7 @@ namespace BDInfo
                         }
 
                         string streamBitrate = string.Format(CultureInfo.InvariantCulture,
-                                                            "{0:N0}",
+                                                            "{0:D}",
                                                             (int)Math.Round((double)stream.BitRate / 1000));
                         if (stream.AngleIndex > 0)
                         {


### PR DESCRIPTION
Remove the comma separation for video bitrates in the report. This formatting was added in v7.6.1, reverting it back to what it was in v7.6.0.